### PR TITLE
Fix Monaco-Powerline file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Link vimrc and gvimrc to your home directory:
 
 Open "mensch-Powerline.otf" and click "Install font" to install Powerline's font which supports fancy characters.
 
-	open Monaco-Powerline.otf
+	open .vim/Monaco-Powerline.otf
 
 Open Vim:
 


### PR DESCRIPTION
Monaco-Powerline.otf file is located in the `.vim` folder, not in `~`.