### PR TITLE
including new useful configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 tmp/
 bundle/
 !bundle/Vundle.vim
+*.swp
+.netrwhist

--- a/vimrc
+++ b/vimrc
@@ -114,6 +114,12 @@ set statusline=[%n]\ %<%.99f\ %h%w%m%r%y\ %{exists('*CapsLockStatusline')?CapsLo
 " Always diff using vertical mode
 set diffopt+=vertical
 
+" Allows the mouse to be used
+set mouse=a
+
+" Automatically reads changed files
+set autoread
+
 
 " Enable syntax highlighting
 syntax on
@@ -286,6 +292,9 @@ endfunction
 " Specific shiftwidth for ruby files
 autocmd FileType ruby set shiftwidth=2
 autocmd FileType ruby set tabstop=2
+" Convert tabs to spaces in Ruby files
+autocmd FileType ruby set expandtab
+
 " But not for erb files...
 autocmd FileType eruby set shiftwidth=4
 autocmd FileType eruby set tabstop=4


### PR DESCRIPTION
Included some new useful configurations in the vimfile.

Autoread: reloads your files whenever there was a change, as long as you have unsaved changes.

Mouse = a: enables the mouse to be used in the terminal version of vim

expandtab: converts tabs to spaces in ruby files. I've included this because the majority of [ruby styleguides](https://github.com/bbatsov/ruby-style-guide#spaces-indentation) sugest you use spaces rather than tabs

